### PR TITLE
Display rockets - Lists render

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
       "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
       "react/react-in-jsx-scope": "off",
       "import/no-unresolved": "off",
+      "no-console": "off",
       "no-shadow": "off"
     },
     "overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,6 @@
       "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
       "react/react-in-jsx-scope": "off",
       "import/no-unresolved": "off",
-      "no-console": "off",
       "no-shadow": "off"
     },
     "overrides": [

--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -12,12 +12,12 @@ const Rockets = () => {
   }, [dispatch]);
 
   if (status) {
-    return <div className="loading">Loading, please wait....</div>;
+    return <div className="loading">Loading, please wait...</div>;
   }
 
   if (error) {
     return (
-      <div className="error">Error loading rocket list, please try again!</div>
+      <div className="error">Error loading!</div>
     );
   }
 

--- a/src/components/Rockets.module.css
+++ b/src/components/Rockets.module.css
@@ -1,10 +1,11 @@
 .rocket_container {
-  border-top: 1px solid black;
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 50px;
   margin: 5px 0;
-  padding-top: 20px;
+  padding-top: 40px;
+  padding-left: 100px;
+  padding-right: 100px;
 }
 
 .space {
@@ -23,9 +24,9 @@
 }
 
 .details {
-  flex: 4;
   display: flex;
   flex-direction: column;
+  flex: 4;
   gap: 10px;
 }
 


### PR DESCRIPTION
In this phase, I have done the following tasks:
- **Used** `useSelector()` Redux Hook to select the state slices and render lists of rockets in corresponding routes.
- **Updated** the overall structure of the rockets page after adding the renders. 