### PR TITLE
Switch badges for Rockets - Conditional components

### DIFF
--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -32,6 +32,7 @@ const Rockets = () => {
             <h2>{rocket.rocket_name}</h2>
             <p>{rocket.description}</p>
             {rocket.reserved && (
+              // render Cancel Rocket button
               <button
                 type="button"
                 className={styles.cancel_reserve_rocket_btn}
@@ -41,6 +42,7 @@ const Rockets = () => {
               </button>
             )}
             {!rocket.reserved && (
+              // render Reserve Rocket button
               <button
                 type="button"
                 className={styles.reserve_rocket_btn}


### PR DESCRIPTION
In this phase, I have used the React conditional rendering syntax which shows Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket".

![image](https://github.com/katarighe/space-travellers/assets/80690364/ee715b0a-fc57-4cf6-a7fa-e8189fe4ed37)
![image](https://github.com/katarighe/space-travellers/assets/80690364/c308f464-7a6d-40af-8ca4-a01d4151d6c2)
