### PR TITLE
Booking cancelation and switch badges for dragon

### DIFF
--- a/src/components/Dragons.js
+++ b/src/components/Dragons.js
@@ -23,12 +23,13 @@ const Dragons = () => {
           </div>
           <div className={styles.d_name_type}>
             <h2 className={styles.dragon_name}>{dragon.name}</h2>
-            <p className={styles.dragon_type}>{dragon.type}</p>
-            {!dragon.reserved ? (
-              <button type="button" className={styles.dragon_button} onClick={() => dispatch(reserveDragon(dragon.id))}>
-                Reserve Dragon
-              </button>
-            ) : null}
+            <p className={styles.dragon_type}>
+              {dragon.reserved && <button type="button" className={styles.dragon_reserved}>Reserved</button>}
+              {dragon.type}
+            </p>
+            <button type="button" className={dragon.reserved ? styles.dragon_cancel : styles.dragon_button} onClick={() => dispatch(reserveDragon(dragon.id))}>
+              {dragon.reserved ? 'Cancel Reservation' : 'Reserve Dragon'}
+            </button>
           </div>
         </div>
       ))}

--- a/src/components/Dragons.module.css
+++ b/src/components/Dragons.module.css
@@ -28,7 +28,25 @@
   padding: 5px;
   border: none;
   background-color: #007bff;
+  border-radius: 3px;
   color: white;
+}
+
+.dragon_cancel {
+  padding: 5px;
+  border: 1px solid #4d5053;
+  background-color: white;
+  border-radius: 3px;
+  color: #9DA2A8;
+}
+
+.dragon_reserved {
+  padding: 3px;
+  border: none;
+  background-color: #007bff;
+  border-radius: 3px;
+  color: white;
+  margin-right: 3px;
 }
 
 .dragon_name {

--- a/src/components/Dragons.module.css
+++ b/src/components/Dragons.module.css
@@ -37,7 +37,7 @@
   border: 1px solid #4d5053;
   background-color: white;
   border-radius: 3px;
-  color: #9DA2A8;
+  color: #9da2a8;
 }
 
 .dragon_reserved {

--- a/src/redux/dragons/dragonsSlice.js
+++ b/src/redux/dragons/dragonsSlice.js
@@ -19,7 +19,7 @@ const dragonsSlice = createSlice({
       const id = action.payload;
       const newState = state.dragons.map((dragon) => {
         if (dragon.id !== id) return dragon;
-        return { ...dragon, reserved: true };
+        return { ...dragon, reserved: !dragon.reserved };
       });
       state.dragons = newState;
     },


### PR DESCRIPTION
This pull request adds the ability to unreserve dragons.

- I followed the same logic as with the "Reserve dragon" action but set the reserved key to false.
- I dispatched these actions upon click on the corresponding buttons.
- Dragons that have already been reserved now show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve dragon" button.

Thank you for your review.